### PR TITLE
Arduino example: fixed undefined reference error

### DIFF
--- a/Example/nrf24l01_library_receiver.ino
+++ b/Example/nrf24l01_library_receiver.ino
@@ -1,6 +1,8 @@
 /*receiver code example, prints the received payload to the Serial monitor in HEX format*/
 /*static payload length of 1 byte, 1Mbps datarate, -6 dbm rf transmit power, channel 32 of 125 chanels*/
-#include "nrf24l01.h"
+extern "C"{
+	#include "nrf24l01.h"
+}
 
 void setup()
 {

--- a/Example/nrf24l01_library_transmitter.ino
+++ b/Example/nrf24l01_library_transmitter.ino
@@ -1,6 +1,8 @@
 /*transmitter code example, transmits an ascending number every TIME_GAP milliseconds in NO_ACK mode*/
 /*static payload length of 1 byte, 1Mbps datarate, -6 dbm rf transmit power, channel 32 of 125 chanels*/
-#include "nrf24l01.h"
+extern "C"{
+	#include "nrf24l01.h"
+}
 
 #define TIME_GAP    500
 

--- a/Example/nrf24l01_low_level.c
+++ b/Example/nrf24l01_low_level.c
@@ -1,5 +1,6 @@
 /*low level api example for avr/arduino*/
 #include "nrf24l01.h"
+#include <Arduino.h>
 
 /*macros for SPI, CE and CSN pin configuration, change pins # according to mcu*/
 #define MOSI_PIN    11


### PR DESCRIPTION
due to linker not knowing the include is for a C file (mangled function names), changed to _low_level.c and included <Arduino>