### PR TITLE
added functions to detect whether channel is busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LEVEL 3:
  *  void nrf24_mode(uint8_t mode)
  *  void nrf24_crc_configuration(uint8_t crc_enable, uint8_t crc_encoding_scheme)
  *  void nrf24_interrupt_mask(uint8_t rx_mask, uint8_t tx_mask, uint8_t max_rt_mask)
+ *  uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test)
  *  void nrf24_rf_channel(uint8_t rf_channel)
  *  void nrf24_rf_power(uint8_t rf_power)
  *  void nrf24_rf_datarate(uint8_t rf_datarate)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ LEVEL 3:
  *  void nrf24_mode(uint8_t mode)
  *  void nrf24_crc_configuration(uint8_t crc_enable, uint8_t crc_encoding_scheme)
  *  void nrf24_interrupt_mask(uint8_t rx_mask, uint8_t tx_mask, uint8_t max_rt_mask)
+ *  uint8_t nrf24_rf_channel_read_busy(uint8_t rf_channel)
  *  uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test)
  *  void nrf24_rf_channel(uint8_t rf_channel)
  *  void nrf24_rf_power(uint8_t rf_power)

--- a/nrf24l01.c
+++ b/nrf24l01.c
@@ -403,6 +403,19 @@ void nrf24_rf_power(uint8_t rf_power)
   nrf24_write(RF_SETUP_ADDRESS, &register_new_value, 1, CLOSE);
 }
 
+/*read whether the current channel is busy (has traffic), needs to be called from RX mode*/
+uint8_t nrf24_rf_channel_read_busy(uint8_t rf_channel)
+{
+  uint8_t signals_detected;
+  nrf24_read(RPD_REG_ADDRESS, &signals_detected, 1, CLOSE);
+  if (signals_detected) {
+    return CHANNEL_BUSY;
+  }
+  else {
+    return CHANNEL_CLEAR;
+  }
+}
+
 /*test whether a channel is busy (has traffic), waiting for ms_to_test*/
 uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test)
 {
@@ -422,8 +435,7 @@ uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test)
     // wait at least 1 ms before declaring channel clear
     delay_function(1 > ms_to_test ? 1 : ms_to_test);
     // Received Power Detector latches to 1 if there was a signal >-64dBm for at least 40 uS consecutively since RX mode was enabled
-    uint8_t signals_detected;
-    nrf24_read(RPD_REG_ADDRESS, &signals_detected, 1, CLOSE);
+    uint8_t signals_detected = nrf24_rf_channel_read_busy(rf_channel);
     // switch back to old channel
     nrf24_rf_channel(previous_channel);
     // switch back to old mode

--- a/nrf24l01.h
+++ b/nrf24l01.h
@@ -189,6 +189,7 @@ void nrf24_mode(uint8_t mode);
 void nrf24_SPI(uint8_t input);
 void nrf24_CE(uint8_t input);
 void nrf24_address_width(uint8_t address_width);
+uint8_t nrf24_rf_channel_read_busy(uint8_t rf_channel);
 uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test);
 void nrf24_rf_channel(uint8_t rf_channel);
 void nrf24_rf_power(uint8_t rf_power);

--- a/nrf24l01.h
+++ b/nrf24l01.h
@@ -62,6 +62,9 @@
 #define RECEIVE_FIFO_EMPTY            2
 #define TX_BUFFER                     1
 #define RX_BUFFER                     0
+// return states for nrf24_rf_channel_test_busy
+#define CHANNEL_CLEAR                 0
+#define CHANNEL_BUSY                  1
 
 /*bits definition section*/
 #define MASK_RX_DR          6               /*mask interrupt caused by RX_DR: 1 interrupt not reflected on IRQ pin (IRQ is active low), inside CONFIG register*/
@@ -112,7 +115,6 @@
 #define RX_P_NO_2           3
 #define RX_P_NO_1           2
 #define RX_P_NO_0           1
-#define TX_FULL             0
 #define PLOS_CNT_3          7               /*inside OBSERVE_TX register, counts the total number of retransmissions since last channel change. reset by writing to RF_CH*/
 #define PLOS_CNT_2          6
 #define PLOS_CNT_1          5
@@ -187,9 +189,10 @@ void nrf24_mode(uint8_t mode);
 void nrf24_SPI(uint8_t input);
 void nrf24_CE(uint8_t input);
 void nrf24_address_width(uint8_t address_width);
+uint8_t nrf24_rf_channel_test_busy(uint8_t rf_channel, uint16_t ms_to_test);
 void nrf24_rf_channel(uint8_t rf_channel);
 void nrf24_rf_power(uint8_t rf_power);
-void nrf24_rf_datarate(uint8_t rf_datarate);
+void nrf24_rf_datarate(uint16_t rf_datarate);
 void nrf24_read(uint8_t address, uint8_t *value, uint8_t data_length, uint8_t spi_state);
 void nrf24_write(uint8_t address, uint8_t *value, uint8_t data_length, uint8_t spi_state);
 void delay_function(uint32_t duration_ms);


### PR DESCRIPTION
We can now test whether a channel is busy or not before jumping there.
The implementation is blocking.
Also a small fix: nrf24_rf_datarate() took uint8_t but values of uint16_t are to be expected.